### PR TITLE
기본 파서로 ESLint의 파서를 사용하고, babel을 사용하는 프로젝트에서만 babel 파서를 사용합니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,31 +67,9 @@ module.exports = {
 }
 ```
 
-#### babel을 사용하지 않는 프로젝트
+#### babel을 사용하는 프로젝트
 
-Babel을 사용하지 않는 프로젝트에서 Babel 설정을 찾을 수 없다는 파싱 에러가 발생합니다.
-다음을 설정에 추가해주세요.
-
-```js
-module.exports = {
-  ...createConfig({ type: 'node' }),
-
-  parserOptions: {
-    requireConfigFile: false,
-  },
-}
-```
-
-또는,
-
-```json
-{
-  "extends": "@titicaca/eslint-config-triple",
-  "parserOptions": {
-    "requireConfigFile": false
-  }
-}
-```
+`createConfig` 함수를 사용하여 설정했을 때, 소스 코드에 Babel 설정 파일(`babel.config.json`)이 있으면 자동으로 `@babel/eslint-parser`를 사용합니다.
 
 #### typescript
 

--- a/create-config.js
+++ b/create-config.js
@@ -1,3 +1,5 @@
+const { readdirSync } = require('fs')
+
 const {
   createNamingConventionConfig,
   createNamingConventionOptions,
@@ -20,8 +22,11 @@ function createConfig({
     throw new Error('type 파라미터가 없습니다. ("frontend" | "node")')
   }
 
+  const hasBabel = checkBabelExist()
+
   return {
     extends: extendCandidates[type] || extendCandidates.node,
+    parser: hasBabel ? '@babel/eslint-parser' : undefined,
     overrides: [
       {
         files: ['*.ts', '*.tsx'],
@@ -65,3 +70,18 @@ function createConfig({
 }
 
 module.exports = createConfig
+
+function checkBabelExist({ cwd = process.cwd() } = {}) {
+  const files = readdirSync(cwd)
+
+  const babelrcWithoutExtension = /\.babelrc$/
+  const babelrcWithExtension = /\.babelrc\.(json|js|cjs|mjs)$/
+  const babelConfig = /babel\.config\.(json|js|cjs|mjs)$/
+
+  return files.some(
+    (file) =>
+      babelrcWithoutExtension.test(file) ||
+      babelrcWithExtension.test(file) ||
+      babelConfig.test(file),
+  )
+}

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 module.exports = {
-  parser: '@babel/eslint-parser',
   extends: [
     'eslint:recommended',
     'plugin:import/recommended',

--- a/test/__snapshots__/config.test.js.snap
+++ b/test/__snapshots__/config.test.js.snap
@@ -1091,7 +1091,7 @@ Object {
   },
   "ignorePatterns": Array [],
   "noInlineConfig": undefined,
-  "parser": StringMatching /@babel\\\\/eslint-parser/,
+  "parser": null,
   "parserOptions": Object {
     "ecmaFeatures": Object {
       "jsx": true,

--- a/test/__snapshots__/create-config.test.js.snap
+++ b/test/__snapshots__/create-config.test.js.snap
@@ -2031,7 +2031,7 @@ Object {
   },
   "ignorePatterns": Array [],
   "noInlineConfig": undefined,
-  "parser": StringMatching /@babel\\\\/eslint-parser/,
+  "parser": null,
   "parserOptions": Object {
     "ecmaFeatures": Object {
       "jsx": true,

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -11,9 +11,7 @@ test('eslint javascript config', async () => {
 
   const config = await eslint.calculateConfigForFile('./mock.js')
 
-  expect(config).toMatchSnapshot({
-    parser: expect.stringMatching(/@babel\/eslint-parser/),
-  })
+  expect(config).toMatchSnapshot()
 })
 
 test('eslint typescript config', async () => {

--- a/test/create-config.test.js
+++ b/test/create-config.test.js
@@ -15,9 +15,7 @@ test('eslint createConfig javascript', async () => {
 
   const config = await eslint.calculateConfigForFile('./mock.js')
 
-  expect(config).toMatchSnapshot({
-    parser: expect.stringMatching(/@babel\/eslint-parser/),
-  })
+  expect(config).toMatchSnapshot()
 })
 
 test('eslint createConfig typescript', async () => {


### PR DESCRIPTION
Fixes #175 

기본 파서를 변경하는 것이기 때문에 Breaking Change입니다.

