### PR TITLE
3.0.1을 릴리즈합니다.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v3.0.1
+
+- 기본 파서로 ESLint의 파서를 사용 [#176](https://github.com/titicacadev/eslint-config-triple/pull/176)
+- babel을 사용하는 프로젝트인지 확인하고 `@babel/eslint-parser`를 사용하는 기능 추가 [#176](https://github.com/titicacadev/eslint-config-triple/pull/176)
+
 ## v3.0.0
 
 ### 주요 변경 사항

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@titicaca/eslint-config-triple",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@titicaca/eslint-config-triple",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "@babel/eslint-parser": "7.15.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/eslint-config-triple",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Triple's ESLint config, following our styleguide",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
- 기본 파서로 ESLint의 파서를 사용 [#176](https://github.com/titicacadev/eslint-config-triple/pull/176)
- babel을 사용하는 프로젝트인지 확인하고 `@babel/eslint-parser`를 사용하는 기능 추가 [#176](https://github.com/titicacadev/eslint-config-triple/pull/176)