### PR TITLE
타입스크립트 파일을 바벨 파서로 파싱하는 문제를 해결합니다.

### DIFF
--- a/create-config.js
+++ b/create-config.js
@@ -6,11 +6,6 @@ const {
   addReactComponentNamingConvention,
 } = require('./rules/typescript/naming-convention')
 
-const extendCandidates = {
-  frontend: ['.', './frontend'].map(require.resolve),
-  node: ['.'].map(require.resolve),
-}
-
 function createConfig({
   type,
   allowedNames = [],
@@ -23,10 +18,13 @@ function createConfig({
     throw new Error('type 파라미터가 없습니다. ("frontend" | "node")')
   }
 
+  const { overrides, ...restConfig } = getBaseConfig(type)
+
   return {
-    extends: extendCandidates[type] || extendCandidates.node,
+    ...restConfig,
     parser: hasBabel ? '@babel/eslint-parser' : undefined,
     overrides: [
+      ...overrides,
       {
         files: ['*.ts', '*.tsx'],
         rules: {
@@ -83,4 +81,23 @@ function checkBabelExist({ cwd = process.cwd() } = {}) {
       babelrcWithExtension.test(file) ||
       babelConfig.test(file),
   )
+}
+
+function getBaseConfig(type) {
+  const base = require('.')
+
+  if (type === 'frontend') {
+    const frontend = require('./frontend')
+
+    return {
+      ...base,
+      ...frontend,
+      extends: [...base.extends, ...frontend.extends],
+      overrides: [...base.overrides, ...frontend.overrides],
+    }
+  }
+
+  return {
+    ...base,
+  }
 }

--- a/create-config.js
+++ b/create-config.js
@@ -17,12 +17,11 @@ function createConfig({
   project,
   tsconfigRootDir,
   enableTypeCheck,
+  hasBabel = checkBabelExist(),
 } = {}) {
   if (type === undefined) {
     throw new Error('type 파라미터가 없습니다. ("frontend" | "node")')
   }
-
-  const hasBabel = checkBabelExist()
 
   return {
     extends: extendCandidates[type] || extendCandidates.node,

--- a/test/create-config.test.js
+++ b/test/create-config.test.js
@@ -59,3 +59,25 @@ test('eslint createConfig frontend type', async () => {
     parser: expect.stringMatching(/@typescript-eslint/),
   })
 })
+
+test('babel 파서를 사용하더라도 타입스크립트 파일은 타입스크립트 파서를 사용합니다.', async () => {
+  const runTest = async (type) => {
+    const overrideConfig = createConfig({
+      type,
+      enableTypeCheck: false,
+      hasBabel: true,
+    })
+    const eslint = new ESLint({
+      extensions: ['js', 'jsx', 'ts', 'tsx'],
+      overrideConfig,
+      useEslintrc: false,
+    })
+
+    const { parser } = await eslint.calculateConfigForFile('./foo.ts')
+
+    expect(parser).toEqual(expect.stringMatching(/@typescript-eslint\//))
+  }
+
+  await runTest('node')
+  await runTest('frontend')
+})


### PR DESCRIPTION
Fixes #182 

기존에는 `extends`로 설정을 병합하고 있었는데 #176 에서 createConfig에서 `parser` 옵션을 직접 추가하면서 `parser` 옵션이 무조건 babel 파서를 바라보는 문제가 있었습니다.

`createConfig`에서 설정을 직접 병합하도록 변경하여 우선순위 문제를 우회합니다.