### PR TITLE
jsx에서 stylelint 작동하지 않는 문제 해결

### DIFF
--- a/stylelint.js
+++ b/stylelint.js
@@ -8,8 +8,13 @@ module.exports = {
     {
       files: ['**/*.{js,ts,tsx}'],
       customSyntax: '@stylelint/postcss-css-in-js',
-      extends: ['stylelint-config-styled-components'],
       rules: {
+        // https://github.com/styled-components/stylelint-config-styled-components/blob/master/index.js
+        'value-no-vendor-prefix': true,
+        'property-no-vendor-prefix': true,
+        'no-empty-source': null,
+        'no-missing-end-of-source-newline': null,
+
         'function-name-case': null,
         'value-keyword-case': null,
       },


### PR DESCRIPTION
stylelint 컨픽이 잘못되어서 jsx에서 stylelint가 작동하지 않습니다.

`overrides.extends` 필드가 유효한 사용 방법이 아닌 것으로 확인해서 `stylelint-config-styled-components` 의 규칙을 복사해옵니다.