### PR TITLE
react/jsx-runtime 플러그인을 사용합니다

### DIFF
--- a/frontend.js
+++ b/frontend.js
@@ -7,10 +7,10 @@ const {
 module.exports = {
   extends: [
     'plugin:react/recommended',
-    'plugin:react/jsx-runtime',
     'plugin:react-hooks/recommended',
     'plugin:jsx-a11y/recommended',
     'standard-jsx',
+    'plugin:react/jsx-runtime',
     ...['./rules/react', './rules/react-hooks', './rules/prettier'].map(
       require.resolve,
     ),

--- a/frontend.js
+++ b/frontend.js
@@ -7,6 +7,7 @@ const {
 module.exports = {
   extends: [
     'plugin:react/recommended',
+    'plugin:react/jsx-runtime',
     'plugin:react-hooks/recommended',
     'plugin:jsx-a11y/recommended',
     'standard-jsx',

--- a/test/__snapshots__/config.test.js.snap
+++ b/test/__snapshots__/config.test.js.snap
@@ -12,6 +12,7 @@ Object {
       "jsx": true,
     },
     "ecmaVersion": 2021,
+    "jsxPragma": null,
     "sourceType": "module",
   },
   "plugins": Array [
@@ -859,7 +860,7 @@ Object {
       0,
     ],
     "react/react-in-jsx-scope": Array [
-      2,
+      0,
     ],
     "react/require-render-return": Array [
       "error",

--- a/test/__snapshots__/config.test.js.snap
+++ b/test/__snapshots__/config.test.js.snap
@@ -797,7 +797,7 @@ Object {
       },
     ],
     "react/jsx-uses-react": Array [
-      "error",
+      0,
     ],
     "react/jsx-uses-vars": Array [
       "error",

--- a/test/__snapshots__/create-config.test.js.snap
+++ b/test/__snapshots__/create-config.test.js.snap
@@ -19,6 +19,7 @@ Object {
       "jsx": true,
     },
     "ecmaVersion": 2021,
+    "jsxPragma": null,
     "project": "./tsconfig.json",
     "sourceType": "module",
     "tsconfigRootDir": "~/mock-dir-name",
@@ -1690,7 +1691,7 @@ Object {
       0,
     ],
     "react/react-in-jsx-scope": Array [
-      2,
+      0,
     ],
     "react/require-render-return": Array [
       "error",

--- a/test/__snapshots__/create-config.test.js.snap
+++ b/test/__snapshots__/create-config.test.js.snap
@@ -1628,7 +1628,7 @@ Object {
       },
     ],
     "react/jsx-uses-react": Array [
-      "error",
+      0,
     ],
     "react/jsx-uses-vars": Array [
       "error",


### PR DESCRIPTION
react17 커버리지가 많아졌으므로 `'react/react-in-jsx-scope'` 룰을 꺼주는 플러그인을 사용합니다.