### PR TITLE
eslint-plugin-prettier 제거

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "eslint-plugin-import": "2.25.2",
         "eslint-plugin-jsx-a11y": "6.4.1",
         "eslint-plugin-node": "11.1.0",
-        "eslint-plugin-prettier": "4.0.0",
         "eslint-plugin-promise": "5.1.0",
         "eslint-plugin-react": "7.26.1",
         "eslint-plugin-react-hooks": "4.2.0",
@@ -3391,26 +3390,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/eslint-plugin-prettier": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
-      "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
-      "dependencies": {
-        "prettier-linter-helpers": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.28.0",
-        "prettier": ">=2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint-config-prettier": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/eslint-plugin-promise": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.1.0.tgz",
@@ -3797,11 +3776,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-    },
-    "node_modules/fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
     },
     "node_modules/fast-glob": {
       "version": "3.2.7",
@@ -7641,17 +7615,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-      "dependencies": {
-        "fast-diff": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/pretty-format": {
@@ -11725,14 +11688,6 @@
         }
       }
     },
-    "eslint-plugin-prettier": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
-      "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
-      "requires": {
-        "prettier-linter-helpers": "^1.0.0"
-      }
-    },
     "eslint-plugin-promise": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.1.0.tgz",
@@ -11929,11 +11884,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-    },
-    "fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
     },
     "fast-glob": {
       "version": "3.2.7",
@@ -14765,14 +14715,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
       "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA=="
-    },
-    "prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-      "requires": {
-        "fast-diff": "^1.1.2"
-      }
     },
     "pretty-format": {
       "version": "27.3.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "eslint-plugin-import": "2.25.2",
     "eslint-plugin-jsx-a11y": "6.4.1",
     "eslint-plugin-node": "11.1.0",
-    "eslint-plugin-prettier": "4.0.0",
     "eslint-plugin-promise": "5.1.0",
     "eslint-plugin-react": "7.26.1",
     "eslint-plugin-react-hooks": "4.2.0",

--- a/rules/prettier.js
+++ b/rules/prettier.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ['plugin:prettier/recommended'],
+  extends: ['prettier'],
   rules: {
     /**
      * prettier에서 비활성화하지만 필요에 의해 다시 활성화하는 규칙

--- a/test/__snapshots__/config.test.js.snap
+++ b/test/__snapshots__/config.test.js.snap
@@ -19,7 +19,6 @@ Object {
     "react-hooks",
     "jsx-a11y",
     "react",
-    "prettier",
   ],
   "reportUnusedDisableDirectives": undefined,
   "rules": Object {
@@ -204,9 +203,6 @@ Object {
       "off",
     ],
     "array-element-newline": Array [
-      "off",
-    ],
-    "arrow-body-style": Array [
       "off",
     ],
     "arrow-parens": Array [
@@ -645,12 +641,6 @@ Object {
     ],
     "padded-blocks": Array [
       "off",
-    ],
-    "prefer-arrow-callback": Array [
-      "off",
-    ],
-    "prettier/prettier": Array [
-      "error",
     ],
     "quote-props": Array [
       "off",
@@ -1104,7 +1094,6 @@ Object {
     "promise",
     "node",
     "import",
-    "prettier",
   ],
   "reportUnusedDisableDirectives": undefined,
   "rules": Object {
@@ -1182,9 +1171,6 @@ Object {
       },
     ],
     "array-element-newline": Array [
-      "off",
-    ],
-    "arrow-body-style": Array [
       "off",
     ],
     "arrow-parens": Array [
@@ -1981,9 +1967,6 @@ Object {
         "switches": "never",
       },
     ],
-    "prefer-arrow-callback": Array [
-      "off",
-    ],
     "prefer-const": Array [
       "error",
       Object {
@@ -1999,9 +1982,6 @@ Object {
       Object {
         "disallowRedundantWrapping": true,
       },
-    ],
-    "prettier/prettier": Array [
-      "error",
     ],
     "promise/always-return": Array [
       "error",
@@ -2421,7 +2401,6 @@ Object {
     "node",
     "import",
     "@typescript-eslint",
-    "prettier",
   ],
   "reportUnusedDisableDirectives": undefined,
   "rules": Object {
@@ -2698,9 +2677,6 @@ Object {
       },
     ],
     "array-element-newline": Array [
-      "off",
-    ],
-    "arrow-body-style": Array [
       "off",
     ],
     "arrow-parens": Array [
@@ -3497,9 +3473,6 @@ Object {
         "switches": "never",
       },
     ],
-    "prefer-arrow-callback": Array [
-      "off",
-    ],
     "prefer-const": Array [
       "error",
       Object {
@@ -3520,9 +3493,6 @@ Object {
       "error",
     ],
     "prefer-spread": Array [
-      "error",
-    ],
-    "prettier/prettier": Array [
       "error",
     ],
     "promise/always-return": Array [

--- a/test/__snapshots__/create-config.test.js.snap
+++ b/test/__snapshots__/create-config.test.js.snap
@@ -31,7 +31,6 @@ Object {
     "react-hooks",
     "jsx-a11y",
     "react",
-    "prettier",
     "@typescript-eslint",
   ],
   "reportUnusedDisableDirectives": undefined,
@@ -370,9 +369,6 @@ Object {
       },
     ],
     "array-element-newline": Array [
-      "off",
-    ],
-    "arrow-body-style": Array [
       "off",
     ],
     "arrow-parens": Array [
@@ -1404,9 +1400,6 @@ Object {
         "switches": "never",
       },
     ],
-    "prefer-arrow-callback": Array [
-      "off",
-    ],
     "prefer-const": Array [
       "error",
       Object {
@@ -1427,9 +1420,6 @@ Object {
       "error",
     ],
     "prefer-spread": Array [
-      "error",
-    ],
-    "prettier/prettier": Array [
       "error",
     ],
     "promise/always-return": Array [
@@ -2044,7 +2034,6 @@ Object {
     "promise",
     "node",
     "import",
-    "prettier",
   ],
   "reportUnusedDisableDirectives": undefined,
   "rules": Object {
@@ -2122,9 +2111,6 @@ Object {
       },
     ],
     "array-element-newline": Array [
-      "off",
-    ],
-    "arrow-body-style": Array [
       "off",
     ],
     "arrow-parens": Array [
@@ -2921,9 +2907,6 @@ Object {
         "switches": "never",
       },
     ],
-    "prefer-arrow-callback": Array [
-      "off",
-    ],
     "prefer-const": Array [
       "error",
       Object {
@@ -2939,9 +2922,6 @@ Object {
       Object {
         "disallowRedundantWrapping": true,
       },
-    ],
-    "prettier/prettier": Array [
-      "error",
     ],
     "promise/always-return": Array [
       "error",
@@ -3362,7 +3342,6 @@ Object {
     "promise",
     "node",
     "import",
-    "prettier",
     "@typescript-eslint",
   ],
   "reportUnusedDisableDirectives": undefined,
@@ -3685,9 +3664,6 @@ Object {
       },
     ],
     "array-element-newline": Array [
-      "off",
-    ],
-    "arrow-body-style": Array [
       "off",
     ],
     "arrow-parens": Array [
@@ -4484,9 +4460,6 @@ Object {
         "switches": "never",
       },
     ],
-    "prefer-arrow-callback": Array [
-      "off",
-    ],
     "prefer-const": Array [
       "error",
       Object {
@@ -4507,9 +4480,6 @@ Object {
       "error",
     ],
     "prefer-spread": Array [
-      "error",
-    ],
-    "prettier/prettier": Array [
       "error",
     ],
     "promise/always-return": Array [


### PR DESCRIPTION
> In other words, use Prettier for formatting and linters for catching bugs!

Prettier는 코드 스타일의 일관성을 교정하는 포맷터고, Eslint는 코드에서 버그를 예방하는 린터입니다. Prettier에서 권장되는 설정으로는 esliint와 통합하지 않고 역할을 서로 분리해서 사용하는 것입니다.  eslint-plugin-prettier를 제거하고 eslint-config-prettier를 사용해서 eslint와 충돌하지 않고 prettier를 별도로 사용할 수 있도록 합니다.

- https://prettier.io/docs/en/integrating-with-linters.html
- https://velog.io/@yrnana/prettier%EC%99%80-eslint%EB%A5%BC-%EA%B5%AC%EB%B6%84%ED%95%B4%EC%84%9C-%EC%82%AC%EC%9A%A9%ED%95%98%EC%9E%90
- https://stackoverflow.com/questions/44690308/whats-the-difference-between-prettier-eslint-eslint-plugin-prettier-and-eslint