### PR TITLE
plugin-configs 폴더를 패키지에 포함하고 require.resolve로 불러옵니다

### DIFF
--- a/create-config.js
+++ b/create-config.js
@@ -54,8 +54,9 @@ function createConfig({
               },
               ...(enableTypeCheck
                 ? {
-                    extends:
+                    extends: require.resolve(
                       './plugin-configs/typescript-requiring-type-checking',
+                    ),
                     parserOptions: { project, tsconfigRootDir },
                   }
                 : {}),

--- a/frontend.js
+++ b/frontend.js
@@ -6,14 +6,18 @@ const {
 
 module.exports = {
   extends: [
-    './plugin-configs/react',
-    './plugin-configs/react-hooks',
-    './plugin-configs/jsx-a11y',
+    ...[
+      './plugin-configs/react',
+      './plugin-configs/react-hooks',
+      './plugin-configs/jsx-a11y',
+    ].map(require.resolve),
     'standard-jsx',
-    './plugin-configs/react-jsx-runtime',
-    ...['./rules/react', './rules/react-hooks', './rules/prettier'].map(
-      require.resolve,
-    ),
+    ...[
+      './plugin-configs/react-jsx-runtime',
+      './rules/react',
+      './rules/react-hooks',
+      './rules/prettier',
+    ].map(require.resolve),
   ],
   settings: {
     react: {

--- a/index.js
+++ b/index.js
@@ -1,8 +1,10 @@
 module.exports = {
   extends: [
-    './plugin-configs/eslint',
-    './plugin-configs/import',
-    './plugin-configs/promise',
+    ...[
+      './plugin-configs/eslint',
+      './plugin-configs/import',
+      './plugin-configs/promise',
+    ].map(require.resolve),
     'standard',
     ...[
       './rules/base',
@@ -25,8 +27,9 @@ module.exports = {
       extends: [
         './plugin-configs/typescript',
         './plugin-configs/import-typescript',
-        ...['./rules/typescript', './rules/prettier'].map(require.resolve),
-      ],
+        './rules/typescript',
+        './rules/prettier',
+      ].map(require.resolve),
       settings: {
         /**
          * import plugin with Typescript configuration

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "files": [
     "rules",
+    "plugin-configs",
     "index.js",
     "prettierrc.js",
     "stylelint.js",


### PR DESCRIPTION
plugin-configs 내의 파일을 찾지 못해서 에러가 발생하고 있었습니다.
```
$ npm run lint

...

Oops! Something went wrong! :(

ESLint: 7.32.0

ESLint couldn't find the config "./plugin-configs/eslint" to extend from. Please check that the name of the config is correct.

The config "./plugin-configs/eslint" was referenced from the config file in "/Users/.../triple-posts-api/.eslintrc.js".

If you still have problems, please stop by https://eslint.org/chat/help to chat with the team.
```