### PR TITLE
off color-function-notation

### DIFF
--- a/stylelint.js
+++ b/stylelint.js
@@ -2,7 +2,7 @@ module.exports = {
   extends: ['stylelint-config-standard', 'stylelint-config-prettier'],
   rules: {
     'alpha-value-notation': 'number',
-    'color-function-notation': 'legacy',
+    'color-function-notation': null,
   },
   overrides: [
     {


### PR DESCRIPTION

color-function-notation은 styled components에서 버그때문에 사용이 불가능해서 이 규칙을 끕니다.

<img width="505" alt="image" src="https://user-images.githubusercontent.com/11497500/199886963-8bc56828-b8af-415d-8cf4-371a646ab844.png">
