### PR TITLE
Release v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v4.1.0
+
+- off color-function-notation [#206](https://github.com/titicacadev/eslint-config-triple/pull/206)
+  - color-function-notation은 styled components에서 버그때문에 사용이 불가능해서 이 규칙을 끕니다.
+
 ## v4.0.0
 
 - eslint-plugin-prettier 제거 [#193](https://github.com/titicacadev/eslint-config-triple/pull/193)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@titicaca/eslint-config-triple",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@titicaca/eslint-config-triple",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "@babel/eslint-parser": "7.15.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/eslint-config-triple",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Triple's ESLint config, following our styleguide",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
## v4.1.0

- off color-function-notation [#206](https://github.com/titicacadev/eslint-config-triple/pull/206)
  - color-function-notation은 styled components에서 버그때문에 사용이 불가능해서 이 규칙을 끕니다.
