### PR TITLE
[stylelint] Stylelint 15 사용, 컨픽 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3857,19 +3857,6 @@
         "@sinonjs/commons": "^2.0.0"
       }
     },
-    "node_modules/@stylelint/postcss-css-in-js": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.38.0.tgz",
-      "integrity": "sha512-XOz5CAe49kS95p5yRd+DAIWDojTjfmyAQ4bbDlXMdbZTQ5t0ThjSLvWI6JI2uiS7MFurVBkZ6zUqcimzcLTBoQ==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dependencies": {
-        "@babel/core": "^7.17.9"
-      },
-      "peerDependencies": {
-        "postcss": ">=7.0.0",
-        "postcss-syntax": ">=0.36.2"
-      }
-    },
     "node_modules/@titicaca/eslint-config-triple": {
       "resolved": "packages/eslint-config-triple",
       "link": true
@@ -7194,6 +7181,11 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -12679,13 +12671,16 @@
         "node": ">=4"
       }
     },
-    "node_modules/postcss-syntax": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
-      "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
-      "peer": true,
+    "node_modules/postcss-styled-syntax": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-styled-syntax/-/postcss-styled-syntax-0.3.1.tgz",
+      "integrity": "sha512-DmZ/IxBqBVRLWMPu2VPCGKc8AkV0dAqQ3VdxDlWckQVzMSxzZW3Y+5vqpSgTo2eQqa+6eBX85rdsrWyrAXhUoQ==",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "^5.47.0",
+        "estree-walker": "^2.0.2"
+      },
       "peerDependencies": {
-        "postcss": ">=5.0.0"
+        "postcss": "^8.4.21"
       }
     },
     "node_modules/postcss-value-parser": {
@@ -15164,7 +15159,7 @@
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@stylelint/postcss-css-in-js": "0.38.0",
+        "postcss-styled-syntax": "^0.3.1",
         "stylelint-config-prettier": "9.0.4",
         "stylelint-config-standard": "29.0.0",
         "stylelint-config-styled-components": "0.1.1"
@@ -15173,7 +15168,7 @@
         "stylelint": "^14.16.1"
       },
       "peerDependencies": {
-        "stylelint": "^14.14.0"
+        "stylelint": "^14.14.0 || ^15.0.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -615,6 +615,49 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.0.1.tgz",
+      "integrity": "sha512-B9/8PmOtU6nBiibJg0glnNktQDZ3rZnGn/7UmDfrm2vMtrdlXO3p7ErE95N0up80IRk9YEtB5jyj/TmQ1WH3dw==",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/csstools"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^2.0.0"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.0.2.tgz",
+      "integrity": "sha512-prUTipz0NZH7Lc5wyBUy93NFy3QYDMVEQgSeZzNdpMbKRd6V2bgRFyJ+O0S0Dw0MXWuE/H9WXlJk3kzMZRHZ/g==",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/csstools"
+      }
+    },
+    "node_modules/@csstools/media-query-list-parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.0.1.tgz",
+      "integrity": "sha512-X2/OuzEbjaxhzm97UJ+95GrMeT29d1Ib+Pu+paGLuRWZnWRK9sI9r3ikmKXPWGA1C4y4JEdBEFpp9jEqCvLeRA==",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/csstools"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.0.0",
+        "@csstools/css-tokenizer": "^2.0.0"
+      }
+    },
     "node_modules/@csstools/selector-specificity": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.1.1.tgz",
@@ -3987,7 +4030,8 @@
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
     },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
@@ -5970,6 +6014,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
       "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
       "dependencies": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -5985,6 +6030,7 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -6008,6 +6054,18 @@
       "integrity": "sha512-/9lCvYZaUbBGvYUgYGFJ4dcYiyqdhSjG7IPVluoV8A1ILjkF7ilmhp1OGUz8n+nmBcu0RNrQAzgD8B6FJbrt2w==",
       "engines": {
         "node": ">=12.22"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "dependencies": {
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/cssesc": {
@@ -10730,6 +10788,11 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
+    },
     "node_modules/meow": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
@@ -13937,139 +14000,6 @@
       "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
       "integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg=="
     },
-    "node_modules/stylelint": {
-      "version": "14.16.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
-      "integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
-      "dependencies": {
-        "@csstools/selector-specificity": "^2.0.2",
-        "balanced-match": "^2.0.0",
-        "colord": "^2.9.3",
-        "cosmiconfig": "^7.1.0",
-        "css-functions-list": "^3.1.0",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.2.12",
-        "fastest-levenshtein": "^1.0.16",
-        "file-entry-cache": "^6.0.1",
-        "global-modules": "^2.0.0",
-        "globby": "^11.1.0",
-        "globjoin": "^0.1.4",
-        "html-tags": "^3.2.0",
-        "ignore": "^5.2.1",
-        "import-lazy": "^4.0.0",
-        "imurmurhash": "^0.1.4",
-        "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.26.0",
-        "mathml-tag-names": "^2.1.3",
-        "meow": "^9.0.0",
-        "micromatch": "^4.0.5",
-        "normalize-path": "^3.0.0",
-        "picocolors": "^1.0.0",
-        "postcss": "^8.4.19",
-        "postcss-media-query-parser": "^0.2.3",
-        "postcss-resolve-nested-selector": "^0.1.1",
-        "postcss-safe-parser": "^6.0.0",
-        "postcss-selector-parser": "^6.0.11",
-        "postcss-value-parser": "^4.2.0",
-        "resolve-from": "^5.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "style-search": "^0.1.0",
-        "supports-hyperlinks": "^2.3.0",
-        "svg-tags": "^1.0.0",
-        "table": "^6.8.1",
-        "v8-compile-cache": "^2.3.0",
-        "write-file-atomic": "^4.0.2"
-      },
-      "bin": {
-        "stylelint": "bin/stylelint.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/stylelint"
-      }
-    },
-    "node_modules/stylelint-config-prettier": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.4.tgz",
-      "integrity": "sha512-38nIGTGpFOiK5LjJ8Ma1yUgpKENxoKSOhbDNSemY7Ep0VsJoXIW9Iq/2hSt699oB9tReynfWicTAoIHiq8Rvbg==",
-      "bin": {
-        "stylelint-config-prettier": "bin/check.js",
-        "stylelint-config-prettier-check": "bin/check.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      },
-      "peerDependencies": {
-        "stylelint": ">=11.0.0"
-      }
-    },
-    "node_modules/stylelint-config-recommended": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-9.0.0.tgz",
-      "integrity": "sha512-9YQSrJq4NvvRuTbzDsWX3rrFOzOlYBmZP+o513BJN/yfEmGSr0AxdvrWs0P/ilSpVV/wisamAHu5XSk8Rcf4CQ==",
-      "peerDependencies": {
-        "stylelint": "^14.10.0"
-      }
-    },
-    "node_modules/stylelint-config-standard": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-29.0.0.tgz",
-      "integrity": "sha512-uy8tZLbfq6ZrXy4JKu3W+7lYLgRQBxYTUUB88vPgQ+ZzAxdrvcaSUW9hOMNLYBnwH+9Kkj19M2DHdZ4gKwI7tg==",
-      "dependencies": {
-        "stylelint-config-recommended": "^9.0.0"
-      },
-      "peerDependencies": {
-        "stylelint": "^14.14.0"
-      }
-    },
-    "node_modules/stylelint-config-styled-components": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/stylelint-config-styled-components/-/stylelint-config-styled-components-0.1.1.tgz",
-      "integrity": "sha512-z5Xz/9GmvxO6e/DLzBMwkB85zHxEEjN6K7Cj80Bi+o/9vR9eS3GX3E9VuMnX9WLFYulqbqLtTapGGY28JBiy9Q=="
-    },
-    "node_modules/stylelint/node_modules/balanced-match": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
-      "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA=="
-    },
-    "node_modules/stylelint/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "node_modules/stylelint/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/stylelint/node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/stylelint/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -14872,6 +14802,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
@@ -15160,15 +15091,145 @@
       "license": "MIT",
       "dependencies": {
         "postcss-styled-syntax": "^0.3.1",
-        "stylelint-config-prettier": "9.0.4",
-        "stylelint-config-standard": "29.0.0",
-        "stylelint-config-styled-components": "0.1.1"
+        "stylelint-config-recommended": "^10.0.1"
       },
       "devDependencies": {
-        "stylelint": "^14.16.1"
+        "stylelint": "^15.1.0"
       },
       "peerDependencies": {
-        "stylelint": "^14.14.0 || ^15.0.0"
+        "stylelint": "^15.0.0"
+      }
+    },
+    "packages/stylelint-config-triple/node_modules/balanced-match": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
+      "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA=="
+    },
+    "packages/stylelint-config-triple/node_modules/cosmiconfig": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.0.0.tgz",
+      "integrity": "sha512-da1EafcpH6b/TD8vDRaWV7xFINlHlF6zKsGwS1TsuVJTZRkquaS5HTMq7uq6h31619QjbsYl21gVDOm32KM1vQ==",
+      "dependencies": {
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "packages/stylelint-config-triple/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "packages/stylelint-config-triple/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/stylelint-config-triple/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/stylelint-config-triple/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/stylelint-config-triple/node_modules/stylelint": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.1.0.tgz",
+      "integrity": "sha512-Tw8OyIiYhxnIHUzgoLlCyWgCUKsPYiP3TDgs7M1VbayS+q5qZly2yxABg+YPe/hFRWiu0cOtptCtpyrn1CrnYw==",
+      "dependencies": {
+        "@csstools/css-parser-algorithms": "^2.0.1",
+        "@csstools/css-tokenizer": "^2.0.1",
+        "@csstools/media-query-list-parser": "^2.0.1",
+        "@csstools/selector-specificity": "^2.1.1",
+        "balanced-match": "^2.0.0",
+        "colord": "^2.9.3",
+        "cosmiconfig": "^8.0.0",
+        "css-functions-list": "^3.1.0",
+        "css-tree": "^2.3.1",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.2.12",
+        "fastest-levenshtein": "^1.0.16",
+        "file-entry-cache": "^6.0.1",
+        "global-modules": "^2.0.0",
+        "globby": "^11.1.0",
+        "globjoin": "^0.1.4",
+        "html-tags": "^3.2.0",
+        "ignore": "^5.2.4",
+        "import-lazy": "^4.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-plain-object": "^5.0.0",
+        "known-css-properties": "^0.26.0",
+        "mathml-tag-names": "^2.1.3",
+        "meow": "^9.0.0",
+        "micromatch": "^4.0.5",
+        "normalize-path": "^3.0.0",
+        "picocolors": "^1.0.0",
+        "postcss": "^8.4.21",
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-resolve-nested-selector": "^0.1.1",
+        "postcss-safe-parser": "^6.0.0",
+        "postcss-selector-parser": "^6.0.11",
+        "postcss-value-parser": "^4.2.0",
+        "resolve-from": "^5.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "style-search": "^0.1.0",
+        "supports-hyperlinks": "^2.3.0",
+        "svg-tags": "^1.0.0",
+        "table": "^6.8.1",
+        "v8-compile-cache": "^2.3.0",
+        "write-file-atomic": "^5.0.0"
+      },
+      "bin": {
+        "stylelint": "bin/stylelint.js"
+      },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/stylelint"
+      }
+    },
+    "packages/stylelint-config-triple/node_modules/stylelint-config-recommended": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-10.0.1.tgz",
+      "integrity": "sha512-TQ4xQ48tW4QSlODcti7pgSRqBZcUaBzuh0jPpfiMhwJKBPkqzTIAU+IrSWL/7BgXlOM90DjB7YaNgFpx8QWhuA==",
+      "peerDependencies": {
+        "stylelint": "^15.0.0"
+      }
+    },
+    "packages/stylelint-config-triple/node_modules/write-file-atomic": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.0.tgz",
+      "integrity": "sha512-R7NYMnHSlV42K54lwY9lvW6MnSm1HSJqZL3xiSgi9E7//FYaI74r2G0rd+/X6VAMkHEdzxQaU5HUOXWUz5kA/w==",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     }
   }

--- a/packages/stylelint-config-triple/package.json
+++ b/packages/stylelint-config-triple/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/titicacadev/eslint-config-triple",
   "dependencies": {
-    "@stylelint/postcss-css-in-js": "0.38.0",
+    "postcss-styled-syntax": "^0.3.1",
     "stylelint-config-prettier": "9.0.4",
     "stylelint-config-standard": "29.0.0",
     "stylelint-config-styled-components": "0.1.1"
@@ -26,6 +26,6 @@
     "stylelint": "^14.16.1"
   },
   "peerDependencies": {
-    "stylelint": "^14.14.0"
+    "stylelint": "^14.14.0 || ^15.0.0"
   }
 }

--- a/packages/stylelint-config-triple/package.json
+++ b/packages/stylelint-config-triple/package.json
@@ -18,14 +18,12 @@
   "homepage": "https://github.com/titicacadev/eslint-config-triple",
   "dependencies": {
     "postcss-styled-syntax": "^0.3.1",
-    "stylelint-config-prettier": "9.0.4",
-    "stylelint-config-standard": "29.0.0",
-    "stylelint-config-styled-components": "0.1.1"
+    "stylelint-config-recommended": "^10.0.1"
   },
   "devDependencies": {
-    "stylelint": "^14.16.1"
+    "stylelint": "^15.1.0"
   },
   "peerDependencies": {
-    "stylelint": "^14.14.0 || ^15.0.0"
+    "stylelint": "^15.0.0"
   }
 }

--- a/packages/stylelint-config-triple/stylelint.js
+++ b/packages/stylelint-config-triple/stylelint.js
@@ -1,23 +1,90 @@
 /** @type {import('stylelint').Config} */
 module.exports = {
-  extends: ['stylelint-config-standard', 'stylelint-config-prettier'],
+  // recommended에는 에러를 막을 수 있는 규칙이 정의되어 있습니다.
+  extends: ['stylelint-config-recommended'],
   rules: {
-    'alpha-value-notation': 'number',
-    'color-function-notation': null,
+    // length
+    'length-zero-no-unit': [
+      true,
+      {
+        ignore: ['custom-properties'],
+      },
+    ],
+
+    // case
+    'function-name-case': 'lower',
+    'selector-type-case': 'lower',
+    'value-keyword-case': 'lower',
+
+    // empty-line-before
+    'at-rule-empty-line-before': [
+      'always',
+      {
+        except: ['blockless-after-same-name-blockless', 'first-nested'],
+        ignore: ['after-comment'],
+      },
+    ],
+    'comment-empty-line-before': [
+      'always',
+      {
+        except: ['first-nested'],
+        ignore: ['stylelint-commands'],
+      },
+    ],
+    'custom-property-empty-line-before': [
+      'always',
+      {
+        except: ['after-custom-property', 'first-nested'],
+        ignore: ['after-comment', 'inside-single-line-block'],
+      },
+    ],
+    'declaration-empty-line-before': [
+      'always',
+      {
+        except: ['after-declaration', 'first-nested'],
+        ignore: ['after-comment', 'inside-single-line-block'],
+      },
+    ],
+    'rule-empty-line-before': [
+      'always-multi-line',
+      {
+        except: ['first-nested'],
+        ignore: ['after-comment'],
+      },
+    ],
+
+    // notation
+    'color-hex-length': 'short',
+    'import-notation': 'url',
+    'keyframe-selector-notation': 'percentage-unless-within-keyword-only-block',
+    'selector-pseudo-element-colon-notation': 'double',
+
+    // quotes
+    'font-family-name-quotes': 'always-where-recommended',
+    'function-url-quotes': 'always',
+    'selector-attribute-quotes': 'always',
+
+    // no-redundant
+    'declaration-block-no-redundant-longhand-properties': true,
+    'shorthand-property-no-redundant-values': true,
+
+    // white-inside
+    'comment-whitespace-inside': 'always',
   },
   overrides: [
     {
       files: ['**/*.{js,ts,tsx}'],
-      customSyntax: require('postcss-styled-syntax'),
+      customSyntax: 'postcss-styled-syntax',
       rules: {
-        // https://github.com/styled-components/stylelint-config-styled-components/blob/master/index.js
-        'value-no-vendor-prefix': true,
-        'property-no-vendor-prefix': true,
+        // postcss-styled-syntax와 같이 사용하면 아직 버그가 있어서 일부 `no-empty`, `case`, 'no-unknown' 규칙을 끕니다.
+        'block-no-empty': null,
         'no-empty-source': null,
-        'no-missing-end-of-source-newline': null,
 
         'function-name-case': null,
         'value-keyword-case': null,
+
+        'annotation-no-unknown': null,
+        'function-no-unknown': null,
       },
     },
   ],

--- a/packages/stylelint-config-triple/stylelint.js
+++ b/packages/stylelint-config-triple/stylelint.js
@@ -8,7 +8,7 @@ module.exports = {
   overrides: [
     {
       files: ['**/*.{js,ts,tsx}'],
-      customSyntax: '@stylelint/postcss-css-in-js',
+      customSyntax: require('postcss-styled-syntax'),
       rules: {
         // https://github.com/styled-components/stylelint-config-styled-components/blob/master/index.js
         'value-no-vendor-prefix': true,

--- a/packages/stylelint-config-triple/stylelint.js
+++ b/packages/stylelint-config-triple/stylelint.js
@@ -74,7 +74,7 @@ module.exports = {
   overrides: [
     {
       files: ['**/*.{js,ts,tsx}'],
-      customSyntax: 'postcss-styled-syntax',
+      customSyntax: require('postcss-styled-syntax'),
       rules: {
         // postcss-styled-syntax와 같이 사용하면 아직 버그가 있어서 일부 `no-empty`, `case`, 'no-unknown' 규칙을 끕니다.
         'block-no-empty': null,


### PR DESCRIPTION
- stylelint 15 버전이 출시되면서 postcss-css-in-js 가 deprecated 되었고 https://www.npmjs.com/package/postcss-styled-syntax 를 사용합니다. https://stylelint.io/migration-guide/to-15
- postcss-styled-syntax와 같이 사용하면 버그가 생기는 규칙이 있어서 일부 규칙은 끕니다.
- stylelint-config-standard를 사용하지 않고 stylelint-config-recommended 기반으로 변경합니다. recommended는 에러 방지 규칙만 정의 되어 있는 컨픽입니다. standard 컨픽은 recommended 컨픽을 기반에 추가적으로 코드 스타일을 제한하는 규칙입니다. 원래 recommended를 사용하다가 standard로 변경한 적이 있습니다. https://github.com/titicacadev/eslint-config-triple/pull/158
그런데 standard 컨픽은 CSS 최신 문법을 강제하는 스타일이라서 브라우저 호환성이 부족한 문제가 있습니다. 그래서 recommended로 돌아가고 standard에서 호환성에 영향은 없지만 간결하고 규칙적인 코드 작성에 유용했던 일부 규칙만 가져오도록 변경했습니다.
